### PR TITLE
Add support for copying symbols

### DIFF
--- a/index.js
+++ b/index.js
@@ -17,7 +17,7 @@ module.exports = (to, from) => {
 	}
 
 	// TODO: use `Reflect.ownKeys()` when targeting Node.js 6
-	for (const prop of Object.getOwnPropertyNames(from)) {
+	for (const prop of Object.getOwnPropertyNames(from).concat(Object.getOwnPropertySymbols(from))) {
 		Object.defineProperty(to, prop, Object.getOwnPropertyDescriptor(from, prop));
 	}
 };

--- a/test.js
+++ b/test.js
@@ -2,8 +2,11 @@ import test from 'ava';
 import m from './';
 
 test(t => {
+	const symbol = Symbol('🦄');
+
 	function foo(bar) {} // eslint-disable-line no-unused-vars
 	foo.unicorn = '🦄';
+	foo[symbol] = '✨';
 
 	function wrapper() {}
 
@@ -14,4 +17,5 @@ test(t => {
 	t.is(wrapper.name, 'foo');
 	t.is(wrapper.length, 1);
 	t.is(wrapper.unicorn, '🦄');
+	t.is(wrapper[symbol], '✨');
 });


### PR DESCRIPTION
Taking the hint from 
> 
```js
// TODO: use `Reflect.ownKeys()` when targeting Node.js 6
```

I added support for symbols to align with [Reflect.ownKeys](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Reflect/ownKeys).