### PR TITLE
Don't use `for (const ...`

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,7 +1,7 @@
 'use strict';
 module.exports = (to, from) => {
 	// TODO: use `Reflect.ownKeys()` when targeting Node.js 6
-	for (const prop of Object.getOwnPropertyNames(from).concat(Object.getOwnPropertySymbols(from))) {
+	for (let prop of Object.getOwnPropertyNames(from).concat(Object.getOwnPropertySymbols(from))) {
 		Object.defineProperty(to, prop, Object.getOwnPropertyDescriptor(from, prop));
 	}
 };


### PR DESCRIPTION
I realise that `for (const ...` is arguably more correct here, since you don't intend to modify the value of `prop` inside the loop body. However, [it doesn't work in some versions of Firefox](https://stackoverflow.com/questions/39044803/syntaxerror-missing-in-const-declaration-firefox-50), which is inconvenient.

Would you consider merging this PR?