### PR TITLE
Return `to` argument

### DIFF
--- a/index.js
+++ b/index.js
@@ -4,4 +4,5 @@ module.exports = (to, from) => {
 	for (const prop of Object.getOwnPropertyNames(from).concat(Object.getOwnPropertySymbols(from))) {
 		Object.defineProperty(to, prop, Object.getOwnPropertyDescriptor(from, prop));
 	}
+	return to;
 };

--- a/readme.md
+++ b/readme.md
@@ -43,6 +43,8 @@ It will copy over the properties `name`, `length`, `displayName`, and any custom
 
 ### mimicFn(to, from)
 
+The function will modify `to` and return it.
+
 #### to
 
 Type: `Function`

--- a/readme.md
+++ b/readme.md
@@ -43,7 +43,7 @@ It will copy over the properties `name`, `length`, `displayName`, and any custom
 
 ### mimicFn(to, from)
 
-The function will modify `to` and return it.
+It will modify `to` and return it.
 
 #### to
 

--- a/test.js
+++ b/test.js
@@ -12,7 +12,7 @@ test(t => {
 
 	t.is(foo.name, 'foo');
 
-	m(wrapper, foo);
+	t.is(m(wrapper, foo), wrapper);
 
 	t.is(wrapper.name, 'foo');
 	t.is(wrapper.length, 1);


### PR DESCRIPTION
Could `mimic-fn` return the `to` argument? This would allow it to be used in conjunction with function expressions, like so:

`const m = mimicFn(function() { return originalFn(); }, originalFn);`