### PR TITLE
Use `Reflect.ownKeys()` and require Node.js 6

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,5 @@
 language: node_js
 node_js:
+  - '10'
   - '8'
   - '6'
-  - '4'

--- a/index.js
+++ b/index.js
@@ -1,7 +1,6 @@
 'use strict';
 module.exports = (to, from) => {
-	// TODO: use `Reflect.ownKeys()` when targeting Node.js 6
-	for (const prop of Object.getOwnPropertyNames(from).concat(Object.getOwnPropertySymbols(from))) {
+	for (const prop of Reflect.ownKeys(from)) {
 		Object.defineProperty(to, prop, Object.getOwnPropertyDescriptor(from, prop));
 	}
 

--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
 		"url": "sindresorhus.com"
 	},
 	"engines": {
-		"node": ">=4"
+		"node": ">=6"
 	},
 	"scripts": {
 		"test": "xo && ava"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "mimic-fn",
-	"version": "1.2.0",
+	"version": "2.0.0",
 	"description": "Make a function mimic another one",
 	"license": "MIT",
 	"repository": "sindresorhus/mimic-fn",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "mimic-fn",
-	"version": "1.0.0",
+	"version": "1.2.0",
 	"description": "Make a function mimic another one",
 	"license": "MIT",
 	"repository": "sindresorhus/mimic-fn",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "mimic-fn",
-	"version": "2.0.0",
+	"version": "1.0.0",
 	"description": "Make a function mimic another one",
 	"license": "MIT",
 	"repository": "sindresorhus/mimic-fn",


### PR DESCRIPTION
Use `Reflect.ownKeys()` when Node.js >= 6.

Because `xo` doesn't support Node.js 4, I make a break change.