### PR TITLE
Add link to related `keep-func-props` package

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -61,6 +61,7 @@ Function to mimic.
 ## Related
 
 - [rename-fn](https://github.com/sindresorhus/rename-fn) - Rename a function
+- [keep-func-props](https://github.com/ehmicky/keep-func-props) - Wrap a function without changing its name, length and other properties
 
 
 ## License


### PR DESCRIPTION
`keep-func-props` is a thin wrapper around `mimic-fn` for the common use case where the "mimicking" happens inside a function wrapper. E.g. for functional helpers like memoize or `once`.

Instead of:

```js
const mimic = require('mimic-fn')
const memoize = require('lodash/memoize')

const anyFunction = function() { return true }

const memoizedFunction = memoize(anyFunction)
mimic(memoizedFunction, anyFunction)
``` 

One can do:

```js
const keepFuncProps = require('keep-func-props')
const memoize = require('lodash/memoize')
const betterMemoize = keepFuncProps(memoize)

const anyFunction = function() { return true }

const memoizedFunction = betterMemoize(anyFunction)
```