### PR TITLE
Add `length` option

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -35,7 +35,8 @@ declare const mimicFn: {
 		FunctionType extends (...arguments: ArgumentsType) => ReturnType
 	>(
 		to: (...arguments: ArgumentsType) => ReturnType,
-		from: FunctionType
+		from: FunctionType,
+		options?: Options
 	): FunctionType;
 
 	// TODO: Remove this for the next major release, refactor the whole definition to:
@@ -50,5 +51,14 @@ declare const mimicFn: {
 	// export = mimicFn;
 	default: typeof mimicFn;
 };
+
+export interface Options {
+	/**
+	 * Modify `Function.length`
+	 *
+	 * @default Use the same `Function.length`
+	 */
+	readonly length?: (length: number) => number;
+}
 
 export = mimicFn;

--- a/index.d.ts
+++ b/index.d.ts
@@ -1,10 +1,20 @@
+declare namespace mimicFn {
+	interface Options {
+		/**
+		Modify `Function#length`
+
+		Default: Use the existing `Function#length`.
+		*/
+		readonly length?: (length: number) => number;
+	}
+}
+
 declare const mimicFn: {
 	/**
 	Make a function mimic another one. It will copy over the properties `name`, `length`, `displayName`, and any custom properties you may have set.
 
 	@param to - Mimicking function.
 	@param from - Function to mimic.
-	@param options - Options
 	@returns The modified `to` function.
 
 	@example
@@ -37,7 +47,7 @@ declare const mimicFn: {
 	>(
 		to: (...arguments: ArgumentsType) => ReturnType,
 		from: FunctionType,
-		options?: Options
+		options?: mimicFn.Options
 	): FunctionType;
 
 	// TODO: Remove this for the next major release, refactor the whole definition to:
@@ -52,14 +62,5 @@ declare const mimicFn: {
 	// export = mimicFn;
 	default: typeof mimicFn;
 };
-
-interface Options {
-	/**
-	 * Modify `Function.length`
-	 *
-	 * @default Use the same `Function.length`
-	 */
-	readonly length?: (length: number) => number;
-}
 
 export = mimicFn;

--- a/index.d.ts
+++ b/index.d.ts
@@ -4,6 +4,7 @@ declare const mimicFn: {
 
 	@param to - Mimicking function.
 	@param from - Function to mimic.
+	@param options - Options
 	@returns The modified `to` function.
 
 	@example
@@ -52,7 +53,7 @@ declare const mimicFn: {
 	default: typeof mimicFn;
 };
 
-export interface Options {
+interface Options {
 	/**
 	 * Modify `Function.length`
 	 *

--- a/index.js
+++ b/index.js
@@ -1,11 +1,38 @@
 'use strict';
 
-const mimicFn = (to, from) => {
+const mimicFn = (to, from, {length: getLength} = {}) => {
 	for (const prop of Reflect.ownKeys(from)) {
-		Object.defineProperty(to, prop, Object.getOwnPropertyDescriptor(from, prop));
+		Object.defineProperty(to, prop, getFuncProp(from, prop, getLength));
 	}
 
 	return to;
+};
+
+const getFuncProp = (func, prop, getLength) => {
+	const descriptor = Object.getOwnPropertyDescriptor(func, prop);
+
+	if (prop === 'length' && getLength !== undefined) {
+		return getLengthProp(descriptor, getLength);
+	}
+
+	return descriptor;
+};
+
+// The function `length` can be changed with the `length` option, which is a
+// function that takes the function `length` as input and returns it.
+const getLengthProp = (descriptor, getLength) => {
+	if (typeof getLength !== 'function') {
+		return descriptor;
+	}
+
+	const newLength = getLength(descriptor.value);
+
+	if (!Number.isInteger(newLength)) {
+		return descriptor;
+	}
+
+	const value = Math.max(0, newLength);
+	return Object.assign({}, descriptor, {value});
 };
 
 module.exports = mimicFn;

--- a/index.js
+++ b/index.js
@@ -1,18 +1,18 @@
 'use strict';
 
-const mimicFn = (to, from, {length: getLength} = {}) => {
+const mimicFn = (to, from, {length} = {}) => {
 	for (const prop of Reflect.ownKeys(from)) {
-		Object.defineProperty(to, prop, getFuncProp(from, prop, getLength));
+		Object.defineProperty(to, prop, getFuncProp(from, prop, length));
 	}
 
 	return to;
 };
 
-const getFuncProp = (func, prop, getLength) => {
+const getFuncProp = (func, prop, length) => {
 	const descriptor = Object.getOwnPropertyDescriptor(func, prop);
 
-	if (prop === 'length' && getLength !== undefined) {
-		return getLengthProp(descriptor, getLength);
+	if (prop === 'length' && length !== undefined) {
+		return getLengthProp(descriptor, length);
 	}
 
 	return descriptor;
@@ -20,12 +20,12 @@ const getFuncProp = (func, prop, getLength) => {
 
 // The function `length` can be changed with the `length` option, which is a
 // function that takes the function `length` as input and returns it.
-const getLengthProp = (descriptor, getLength) => {
-	if (typeof getLength !== 'function') {
+const getLengthProp = (descriptor, length) => {
+	if (typeof length !== 'function') {
 		return descriptor;
 	}
 
-	const newLength = getLength(descriptor.value);
+	const newLength = length(descriptor.value);
 
 	if (!Number.isInteger(newLength)) {
 		return descriptor;

--- a/readme.md
+++ b/readme.md
@@ -41,7 +41,7 @@ console.log(wrapper.unicorn);
 
 It will copy over the properties `name`, `length`, `displayName`, and any custom properties you may have set.
 
-### mimicFn(to, from)
+### mimicFn(to, from, [options])
 
 Modifies the `to` function and returns it.
 
@@ -57,6 +57,34 @@ Type: `Function`
 
 Function to mimic.
 
+#### options
+
+Type: `Object`
+
+##### length
+
+Type: `Function`
+
+Modifies the function's `length` property. Useful when `from` and `to` do not
+have the same number of arguments. This happens for example when binding or
+currying.
+
+```js
+const mimicFn = require('mimic-fn');
+
+const identity = value => value;
+const getTrue = identity.bind(null, true);
+
+mimicFn(getTrue, identity, { length: len => len - 1 });
+console.log(getTrue.name);
+//=> 'identity'
+
+console.log(identity.length);
+//=> 1
+
+console.log(getTrue.length);
+//=> 0
+```
 
 ## Related
 

--- a/readme.md
+++ b/readme.md
@@ -41,7 +41,7 @@ console.log(wrapper.unicorn);
 
 It will copy over the properties `name`, `length`, `displayName`, and any custom properties you may have set.
 
-### mimicFn(to, from, [options])
+### mimicFn(to, from, options?)
 
 Modifies the `to` function and returns it.
 
@@ -59,7 +59,7 @@ Function to mimic.
 
 #### options
 
-Type: `Object`
+Type: `object`
 
 ##### length
 

--- a/test.js
+++ b/test.js
@@ -26,10 +26,14 @@ test('should keep descriptors', t => {
 	const wrapper = function () {};
 	mimicFn(wrapper, foo);
 
-	t.deepEqual(
-		Object.getOwnPropertyDescriptors(wrapper),
-		Object.getOwnPropertyDescriptors(foo)
-	);
+	// TODO: use `Object.getOwnPropertyDescriptors()` after dropping support for
+	// Node 6
+	for (const prop of Reflect.ownKeys(foo)) {
+		t.deepEqual(
+			Object.getOwnPropertyDescriptor(wrapper, prop),
+			Object.getOwnPropertyDescriptor(foo, prop)
+		);
+	}
 });
 
 test('"length" option: should set function length', t => {

--- a/test.js
+++ b/test.js
@@ -1,21 +1,71 @@
 import test from 'ava';
-import mimickFn from '.';
+import mimicFn from '.';
+
+const symbol = Symbol('🦄');
+
+const foo = function (bar) {
+	return bar;
+};
+
+foo.unicorn = '🦄';
+foo[symbol] = '✨';
 
 test('main', t => {
-	const symbol = Symbol('🦄');
-
-	function foo(bar) {} // eslint-disable-line no-unused-vars
-	foo.unicorn = '🦄';
-	foo[symbol] = '✨';
-
-	function wrapper() {}
-
 	t.is(foo.name, 'foo');
 
-	t.is(mimickFn(wrapper, foo), wrapper);
+	const wrapper = function () {};
+	t.is(mimicFn(wrapper, foo), wrapper);
 
 	t.is(wrapper.name, 'foo');
 	t.is(wrapper.length, 1);
 	t.is(wrapper.unicorn, '🦄');
 	t.is(wrapper[symbol], '✨');
+});
+
+test('should keep descriptors', t => {
+	const wrapper = function () {};
+	mimicFn(wrapper, foo);
+
+	t.deepEqual(
+		Object.getOwnPropertyDescriptors(wrapper),
+		Object.getOwnPropertyDescriptors(foo)
+	);
+});
+
+test('"length" option: should set function length', t => {
+	const wrapper = function () {};
+	mimicFn(wrapper, foo, {length: len => len + 1});
+
+	t.is(wrapper.length, 2);
+});
+
+test('"length" option: should keep descriptors', t => {
+	const wrapper = function () {};
+	mimicFn(wrapper, foo, {length: len => len});
+
+	t.deepEqual(
+		Object.getOwnPropertyDescriptor(wrapper, 'length'),
+		Object.getOwnPropertyDescriptor(foo, 'length')
+	);
+});
+
+test('"length" option: should fix negative function length', t => {
+	const wrapper = function () {};
+	mimicFn(wrapper, foo, {length: len => len - 2});
+
+	t.is(wrapper.length, 0);
+});
+
+test('"length" option: should ignore non-integer function length', t => {
+	const wrapper = function () {};
+	mimicFn(wrapper, foo, {length: () => NaN});
+
+	t.is(wrapper.length, 1);
+});
+
+test('"length" option: should ignore if not a function', t => {
+	const wrapper = function () {};
+	mimicFn(wrapper, foo, {length: 2});
+
+	t.is(wrapper.length, 1);
 });

--- a/test.js
+++ b/test.js
@@ -67,7 +67,7 @@ test('"length" option: should ignore non-integer function length', t => {
 	t.is(wrapper.length, 1);
 });
 
-test('"length" option: should ignore if not a function', t => {
+test('`length` option: should ignore if not a function', t => {
 	const wrapper = function () {};
 	mimicFn(wrapper, foo, {length: 2});
 


### PR DESCRIPTION
Fixes #13.

The current implementation ignores the `length` option when it's not a function, as opposed to throw an error. Please let me know if it should throw an error instead. 

Same comment for the value returned by the `length` option, when it does not return an integer.