### PR TITLE
Do not copy `Function#length`

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -1,6 +1,6 @@
 declare const mimicFn: {
 	/**
-	Make a function mimic another one. It will copy over the properties `name`, `displayName`, and any custom properties you may have set. `length` won't be copied.
+	Make a function mimic another one. It will copy over the properties `name`, `displayName`, and any custom properties you may have set. The `length` property won't be copied.
 
 	@param to - Mimicking function.
 	@param from - Function to mimic.

--- a/index.d.ts
+++ b/index.d.ts
@@ -1,6 +1,6 @@
 declare const mimicFn: {
 	/**
-	Make a function mimic another one. It will copy over the properties `name`, `length`, `displayName`, and any custom properties you may have set.
+	Make a function mimic another one. It will copy over the properties `name`, `displayName`, and any custom properties you may have set.
 
 	@param to - Mimicking function.
 	@param from - Function to mimic.

--- a/index.d.ts
+++ b/index.d.ts
@@ -1,6 +1,6 @@
 declare const mimicFn: {
 	/**
-	Make a function mimic another one. It will copy over the properties `name`, `displayName`, and any custom properties you may have set.
+	Make a function mimic another one. It will copy over the properties `name`, `displayName`, and any custom properties you may have set. `length` won't be copied.
 
 	@param to - Mimicking function.
 	@param from - Function to mimic.

--- a/index.js
+++ b/index.js
@@ -1,7 +1,13 @@
 'use strict';
 
+const shouldCopyProp = function (prop) {
+	return prop !== 'length';
+};
+
 const mimicFn = (to, from) => {
-	for (const prop of Reflect.ownKeys(from)) {
+	const props = Reflect.ownKeys(from).filter(shouldCopyProp);
+
+	for (const prop of props) {
 		Object.defineProperty(to, prop, Object.getOwnPropertyDescriptor(from, prop));
 	}
 

--- a/index.js
+++ b/index.js
@@ -1,11 +1,9 @@
 'use strict';
 
-const shouldCopyProp = function (prop) {
-	return prop !== 'length';
-};
+const shouldCopyProperty = property => property !== 'length';
 
 const mimicFn = (to, from) => {
-	const props = Reflect.ownKeys(from).filter(shouldCopyProp);
+	const props = Reflect.ownKeys(from).filter(shouldCopyProperty);
 
 	for (const prop of props) {
 		Object.defineProperty(to, prop, Object.getOwnPropertyDescriptor(from, prop));

--- a/readme.md
+++ b/readme.md
@@ -39,7 +39,7 @@ console.log(wrapper.unicorn);
 
 ## API
 
-It will copy over the properties `name`, `displayName`, and any custom properties you may have set.
+It will copy over the properties `name`, `displayName`, and any custom properties you may have set. `length` won't be copied.
 
 ### mimicFn(to, from)
 

--- a/readme.md
+++ b/readme.md
@@ -39,7 +39,7 @@ console.log(wrapper.unicorn);
 
 ## API
 
-It will copy over the properties `name`, `length`, `displayName`, and any custom properties you may have set.
+It will copy over the properties `name`, `displayName`, and any custom properties you may have set.
 
 ### mimicFn(to, from)
 
@@ -61,7 +61,7 @@ Function to mimic.
 ## Related
 
 - [rename-fn](https://github.com/sindresorhus/rename-fn) - Rename a function
-- [keep-func-props](https://github.com/ehmicky/keep-func-props) - Wrap a function without changing its name, length and other properties
+- [keep-func-props](https://github.com/ehmicky/keep-func-props) - Wrap a function without changing its name and other properties
 
 
 ## License

--- a/readme.md
+++ b/readme.md
@@ -39,7 +39,7 @@ console.log(wrapper.unicorn);
 
 ## API
 
-It will copy over the properties `name`, `displayName`, and any custom properties you may have set. `length` won't be copied.
+It will copy over the properties `name`, `displayName`, and any custom properties you may have set. The `length` property won't be copied.
 
 ### mimicFn(to, from)
 

--- a/test.js
+++ b/test.js
@@ -15,7 +15,7 @@ test('main', t => {
 	t.is(mimickFn(wrapper, foo), wrapper);
 
 	t.is(wrapper.name, 'foo');
-	t.is(wrapper.length, 1);
+	t.is(wrapper.length, 0);
 	t.is(wrapper.unicorn, '🦄');
 	t.is(wrapper[symbol], '✨');
 });


### PR DESCRIPTION
Fixes #13. Previous PR at #18.

This prevents copying `Function#length`. That property should reflect the actual parameters length, not the one of the function that is being copied.

For example:

```js
const original = value => value
const wrapper = () => original(true)
mimicFn(wrapper, original)
// This should be 0 not 1
console.log(wrapper.length)
```