### PR TITLE
Remove `module.exports.default`

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -1,54 +1,40 @@
-declare const mimicFn: {
-	/**
-	Make a function mimic another one. It will copy over the properties `name`, `displayName`, and any custom properties you may have set. The `length` property won't be copied.
+/**
+Make a function mimic another one. It will copy over the properties `name`, `displayName`, and any custom properties you may have set. The `length` property won't be copied.
 
-	@param to - Mimicking function.
-	@param from - Function to mimic.
-	@returns The modified `to` function.
+@param to - Mimicking function.
+@param from - Function to mimic.
+@returns The modified `to` function.
 
-	@example
-	```
-	import mimicFn = require('mimic-fn');
+@example
+```
+import mimicFn = require('mimic-fn');
 
-	function foo() {}
-	foo.unicorn = '🦄';
+function foo() {}
+foo.unicorn = '🦄';
 
-	function wrapper() {
-		return foo();
-	}
+function wrapper() {
+	return foo();
+}
 
-	console.log(wrapper.name);
-	//=> 'wrapper'
+console.log(wrapper.name);
+//=> 'wrapper'
 
-	mimicFn(wrapper, foo);
+mimicFn(wrapper, foo);
 
-	console.log(wrapper.name);
-	//=> 'foo'
+console.log(wrapper.name);
+//=> 'foo'
 
-	console.log(wrapper.unicorn);
-	//=> '🦄'
-	```
-	*/
-	<
-		ArgumentsType extends unknown[],
-		ReturnType,
-		FunctionType extends (...arguments: ArgumentsType) => ReturnType
-	>(
-		to: (...arguments: ArgumentsType) => ReturnType,
-		from: FunctionType
-	): FunctionType;
-
-	// TODO: Remove this for the next major release, refactor the whole definition to:
-	// declare function mimicFn<
-	//	ArgumentsType extends unknown[],
-	//	ReturnType,
-	//	FunctionType extends (...arguments: ArgumentsType) => ReturnType
-	// >(
-	//	to: (...arguments: ArgumentsType) => ReturnType,
-	//	from: FunctionType
-	// ): FunctionType;
-	// export = mimicFn;
-	default: typeof mimicFn;
-};
+console.log(wrapper.unicorn);
+//=> '🦄'
+```
+*/
+declare function mimicFn<
+	ArgumentsType extends unknown[],
+	ReturnType,
+	FunctionType extends (...arguments: ArgumentsType) => ReturnType
+>(
+	to: (...arguments: ArgumentsType) => ReturnType,
+	from: FunctionType
+): FunctionType;
 
 export = mimicFn;

--- a/index.js
+++ b/index.js
@@ -13,5 +13,3 @@ const mimicFn = (to, from) => {
 };
 
 module.exports = mimicFn;
-// TODO: Remove this for the next major release
-module.exports.default = mimicFn;


### PR DESCRIPTION
This removes `module.exports.default` as it marked as "to be deleted in the next major release" and it seems like a new major release might be coming.