### PR TITLE
Delete properties to make functions more similar

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -1,7 +1,7 @@
 /**
 Modifies the `to` function to mimic the `from` function. Returns the `to` function.
 
-`name`, `displayName`, and any other properties from `from` are copied. The `length` property is not copied. Properties present in `to` but not in `from` are deleted.
+`name`, `displayName`, and any other properties of `from` are copied. The `length` property is not copied. Properties present in `to` but not in `from` are deleted.
 
 @param to - Mimicking function.
 @param from - Function to mimic.

--- a/index.d.ts
+++ b/index.d.ts
@@ -1,5 +1,7 @@
 /**
-Make a function mimic another one. It will copy over the properties `name`, `displayName`, and any custom properties you may have set. The `length` property won't be copied.
+Modifies the `to` function to mimic the `from` function. Returns the `to` function.
+
+`name`, `displayName`, and any other properties from `from` are copied. The `length` property is not copied. Properties present in `to` but not in `from` are deleted.
 
 @param to - Mimicking function.
 @param from - Function to mimic.

--- a/index.js
+++ b/index.js
@@ -18,10 +18,10 @@ const removeProperty = function (to, from, property) {
 const shouldCopyProperty = property => property !== 'length';
 
 const mimicFn = (to, from) => {
-	const props = Reflect.ownKeys(from).filter(shouldCopyProperty);
+	const properties = Reflect.ownKeys(from).filter(shouldCopyProperty);
 
-	for (const prop of props) {
-		Object.defineProperty(to, prop, Object.getOwnPropertyDescriptor(from, prop));
+	for (const property of properties) {
+		Object.defineProperty(to, property, Object.getOwnPropertyDescriptor(from, property));
 	}
 
 	Reflect.ownKeys(to).forEach(property => removeProperty(to, from, property));

--- a/index.js
+++ b/index.js
@@ -1,5 +1,20 @@
 'use strict';
 
+// If `to` has properties that `from` does not have, remove them
+const removeProperty = function (to, from, property) {
+	if (property in from) {
+		return;
+	}
+
+	const {configurable, writable} = Object.getOwnPropertyDescriptor(to, property);
+
+	if (configurable) {
+		delete to[property];
+	} else if (writable) {
+		to[property] = undefined;
+	}
+};
+
 const shouldCopyProperty = property => property !== 'length';
 
 const mimicFn = (to, from) => {
@@ -8,6 +23,8 @@ const mimicFn = (to, from) => {
 	for (const prop of props) {
 		Object.defineProperty(to, prop, Object.getOwnPropertyDescriptor(from, prop));
 	}
+
+	Reflect.ownKeys(to).forEach(property => removeProperty(to, from, property));
 
 	return to;
 };

--- a/index.js
+++ b/index.js
@@ -1,7 +1,7 @@
 'use strict';
 
 // If `to` has properties that `from` does not have, remove them
-const removeProperty = function (to, from, property) {
+const removeProperty = (to, from, property) => {
 	if (property in from) {
 		return;
 	}
@@ -23,8 +23,10 @@ const mimicFn = (to, from) => {
 	for (const property of properties) {
 		Object.defineProperty(to, property, Object.getOwnPropertyDescriptor(from, property));
 	}
-
-	Reflect.ownKeys(to).forEach(property => removeProperty(to, from, property));
+	
+	for (const property of Reflect.ownKeys(to)) {
+		removeProperty(to, from, property)
+	}
 
 	return to;
 };

--- a/index.js
+++ b/index.js
@@ -27,7 +27,7 @@ const mimicFn = (to, from) => {
 	}
 
 	for (const property of Reflect.ownKeys(to)) {
-		removeProperty(to, from, property)
+		removeProperty(to, from, property);
 	}
 
 	return to;

--- a/index.js
+++ b/index.js
@@ -1,8 +1,10 @@
 'use strict';
 
+const {hasOwnProperty} = Object.prototype;
+
 // If `to` has properties that `from` does not have, remove them
 const removeProperty = (to, from, property) => {
-	if (property in from) {
+	if (hasOwnProperty.call(from, property)) {
 		return;
 	}
 
@@ -23,7 +25,7 @@ const mimicFn = (to, from) => {
 	for (const property of properties) {
 		Object.defineProperty(to, property, Object.getOwnPropertyDescriptor(from, property));
 	}
-	
+
 	for (const property of Reflect.ownKeys(to)) {
 		removeProperty(to, from, property)
 	}

--- a/readme.md
+++ b/readme.md
@@ -43,7 +43,7 @@ console.log(wrapper.unicorn);
 
 Modifies the `to` function to mimic the `from` function. Returns the `to` function.
 
-`name`, `displayName`, and any other properties from `from` are copied. The `length` property is not copied. Properties present in `to` but not in `from` are deleted.
+`name`, `displayName`, and any other properties of `from` are copied. The `length` property is not copied. Properties present in `to` but not in `from` are deleted.
 
 #### to
 

--- a/readme.md
+++ b/readme.md
@@ -39,11 +39,11 @@ console.log(wrapper.unicorn);
 
 ## API
 
-It will copy over the properties `name`, `displayName`, and any custom properties you may have set. The `length` property won't be copied.
-
 ### mimicFn(to, from)
 
-Modifies the `to` function and returns it.
+Modifies the `to` function to mimic the `from` function. Returns the `to` function.
+
+`name`, `displayName`, and any other properties from `from` are copied. The `length` property is not copied. Properties present in `to` but not in `from` are deleted.
 
 #### to
 

--- a/test.js
+++ b/test.js
@@ -77,8 +77,7 @@ test('should skip extra non-configurable non-writable properties', t => {
 	Object.defineProperty(wrapper, 'extra', {value: true, configurable: false, writable: false});
 	mimicFn(wrapper, foo);
 
-	t.true('extra' in wrapper);
-	t.not(wrapper.extra, undefined);
+	t.is(wrapper.extra, true);
 });
 
 test('should work with arrow functions', t => {

--- a/test.js
+++ b/test.js
@@ -54,3 +54,38 @@ test('should keep descriptors', t => {
 	t.deepEqual(fooProperties, wrapperProperties);
 	t.notDeepEqual(fooLength, wrapperLength);
 });
+
+test('should delete extra configurable writable properties', t => {
+	const wrapper = function () {};
+	wrapper.extra = true;
+	mimicFn(wrapper, foo);
+
+	t.false('extra' in wrapper);
+});
+
+test('should delete extra non-configurable writable properties', t => {
+	const wrapper = function () {};
+	Object.defineProperty(wrapper, 'extra', {value: true, configurable: false, writable: true});
+	mimicFn(wrapper, foo);
+
+	t.true('extra' in wrapper);
+	t.is(wrapper.extra, undefined);
+});
+
+test('should not delete extra non-configurable non-writable properties', t => {
+	const wrapper = function () {};
+	Object.defineProperty(wrapper, 'extra', {value: true, configurable: false, writable: false});
+	mimicFn(wrapper, foo);
+
+	t.true('extra' in wrapper);
+	t.not(wrapper.extra, undefined);
+});
+
+test('should work with arrow functions', t => {
+	const wrapper = function () {};
+	wrapper.extra = true;
+	const arrowFn = () => {};
+	mimicFn(wrapper, arrowFn);
+
+	t.is(wrapper.prototype, arrowFn.prototype);
+});

--- a/test.js
+++ b/test.js
@@ -83,7 +83,6 @@ test('should not delete extra non-configurable non-writable properties', t => {
 
 test('should work with arrow functions', t => {
 	const wrapper = function () {};
-	wrapper.extra = true;
 	const arrowFn = () => {};
 	mimicFn(wrapper, arrowFn);
 

--- a/test.js
+++ b/test.js
@@ -63,7 +63,7 @@ test('should delete extra configurable writable properties', t => {
 	t.false('extra' in wrapper);
 });
 
-test('should delete extra non-configurable writable properties', t => {
+test('should set to undefined extra non-configurable writable properties', t => {
 	const wrapper = function () {};
 	Object.defineProperty(wrapper, 'extra', {value: true, configurable: false, writable: true});
 	mimicFn(wrapper, foo);

--- a/test.js
+++ b/test.js
@@ -72,7 +72,7 @@ test('should set to undefined extra non-configurable writable properties', t => 
 	t.is(wrapper.extra, undefined);
 });
 
-test('should not delete extra non-configurable non-writable properties', t => {
+test('should skip extra non-configurable non-writable properties', t => {
 	const wrapper = function () {};
 	Object.defineProperty(wrapper, 'extra', {value: true, configurable: false, writable: false});
 	mimicFn(wrapper, foo);

--- a/test.js
+++ b/test.js
@@ -1,6 +1,8 @@
 import test from 'ava';
 import mimicFn from '.';
 
+const {hasOwnProperty} = Object.prototype;
+
 const foo = function (bar) {
 	return bar;
 };
@@ -60,7 +62,7 @@ test('should delete extra configurable writable properties', t => {
 	wrapper.extra = true;
 	mimicFn(wrapper, foo);
 
-	t.false('extra' in wrapper);
+	t.false(hasOwnProperty.call(wrapper, 'extra'));
 });
 
 test('should set to undefined extra non-configurable writable properties', t => {
@@ -68,7 +70,7 @@ test('should set to undefined extra non-configurable writable properties', t => 
 	Object.defineProperty(wrapper, 'extra', {value: true, configurable: false, writable: true});
 	mimicFn(wrapper, foo);
 
-	t.true('extra' in wrapper);
+	t.true(hasOwnProperty.call(wrapper, 'extra'));
 	t.is(wrapper.extra, undefined);
 });
 


### PR DESCRIPTION
Fixes #15.

Properties present in `to` but not in `from` are deleted. This allows a better behavior when using arrow functions vs non-arrow functions (which have a different `Function#prototype`).

I've also tried to improve the documentation a little.