### PR TITLE
Copy inherited properties

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -1,7 +1,7 @@
 /**
 Modifies the `to` function to mimic the `from` function. Returns the `to` function.
 
-`name`, `displayName`, and any other properties of `from` are copied. The `length` property is not copied. Properties present in `to` but not in `from` are deleted.
+`name`, `displayName`, and any other properties of `from` are copied. The `length` property is not copied. Properties present in `to` but not in `from` are deleted. Prototype, class and inherited properties are copied.
 
 @param to - Mimicking function.
 @param from - Function to mimic.

--- a/index.d.ts
+++ b/index.d.ts
@@ -1,7 +1,7 @@
 /**
 Modifies the `to` function to mimic the `from` function. Returns the `to` function.
 
-`name`, `displayName`, and any other properties of `from` are copied. The `length` property is not copied. Properties present in `to` but not in `from` are deleted. Prototype, class and inherited properties are copied.
+`name`, `displayName`, and any other properties of `from` are copied. The `length` property is not copied. Properties present in `to` but not in `from` are deleted. Prototype, class, and inherited properties are copied.
 
 @param to - Mimicking function.
 @param from - Function to mimic.

--- a/index.js
+++ b/index.js
@@ -2,6 +2,15 @@
 
 const {hasOwnProperty} = Object.prototype;
 
+const changePrototype = (to, from) => {
+	const fromPrototype = Object.getPrototypeOf(from);
+	if (fromPrototype === Object.getPrototypeOf(to)) {
+		return;
+	}
+
+	Object.setPrototypeOf(to, fromPrototype);
+};
+
 // If `to` has properties that `from` does not have, remove them
 const removeProperty = (to, from, property) => {
 	if (hasOwnProperty.call(from, property)) {
@@ -25,6 +34,8 @@ const mimicFn = (to, from) => {
 	for (const property of properties) {
 		Object.defineProperty(to, property, Object.getOwnPropertyDescriptor(from, property));
 	}
+
+	changePrototype(to, from);
 
 	for (const property of Reflect.ownKeys(to)) {
 		removeProperty(to, from, property);

--- a/readme.md
+++ b/readme.md
@@ -43,7 +43,7 @@ console.log(wrapper.unicorn);
 
 Modifies the `to` function to mimic the `from` function. Returns the `to` function.
 
-`name`, `displayName`, and any other properties of `from` are copied. The `length` property is not copied. Properties present in `to` but not in `from` are deleted. Prototype, class and inherited properties are copied.
+`name`, `displayName`, and any other properties of `from` are copied. The `length` property is not copied. Properties present in `to` but not in `from` are deleted. Prototype, class, and inherited properties are copied.
 
 #### to
 

--- a/readme.md
+++ b/readme.md
@@ -43,7 +43,7 @@ console.log(wrapper.unicorn);
 
 Modifies the `to` function to mimic the `from` function. Returns the `to` function.
 
-`name`, `displayName`, and any other properties of `from` are copied. The `length` property is not copied. Properties present in `to` but not in `from` are deleted.
+`name`, `displayName`, and any other properties of `from` are copied. The `length` property is not copied. Properties present in `to` but not in `from` are deleted. Prototype, class and inherited properties are copied.
 
 #### to
 

--- a/test.js
+++ b/test.js
@@ -12,6 +12,10 @@ foo.unicorn = '🦄';
 const symbol = Symbol('🦄');
 foo[symbol] = '✨';
 
+const parent = function () {};
+parent.inheritedProp = true;
+Object.setPrototypeOf(foo, parent);
+
 test('should return the wrapped function', t => {
 	const wrapper = function () {};
 	const returnValue = mimicFn(wrapper, foo);
@@ -55,6 +59,13 @@ test('should keep descriptors', t => {
 	const {length: wrapperLength, ...wrapperProperties} = Object.getOwnPropertyDescriptors(wrapper);
 	t.deepEqual(fooProperties, wrapperProperties);
 	t.notDeepEqual(fooLength, wrapperLength);
+});
+
+test('should copy inherited properties', t => {
+	const wrapper = function () {};
+	mimicFn(wrapper, foo);
+
+	t.is(wrapper.inheritedProp, foo.inheritedProp);
 });
 
 test('should delete extra configurable writable properties', t => {


### PR DESCRIPTION
Fixes #29.

Copies `__proto__`, which means inherited properties are copied as well.