### PR TITLE
Do not copy functions `prototype`

### DIFF
--- a/index.js
+++ b/index.js
@@ -26,7 +26,9 @@ const removeProperty = (to, from, property) => {
 	}
 };
 
-const shouldCopyProperty = property => property !== 'length';
+// `Function#length` should reflect the parameters of `to` not `from` since we keep its body.
+// `Function#prototype` is non-writable and non-configurable so can never be modified.
+const shouldCopyProperty = property => property !== 'length' && property !== 'prototype';
 
 const mimicFn = (to, from) => {
 	const properties = Reflect.ownKeys(from).filter(shouldCopyProperty);

--- a/test.js
+++ b/test.js
@@ -102,7 +102,7 @@ test('should not copy prototypes', t => {
 	t.is(wrapper.prototype, prototype);
 });
 
-test('should allow classes', t => {
+test('should allow classes to be copied', t => {
 	class wrapperClass {}
 	class fooClass {}
 	mimicFn(wrapperClass, fooClass);

--- a/test.js
+++ b/test.js
@@ -93,10 +93,11 @@ test('should skip extra non-configurable non-writable properties', t => {
 	t.is(wrapper.extra, true);
 });
 
-test('should work with arrow functions', t => {
+test('should not copy prototypes', t => {
 	const wrapper = function () {};
-	const arrowFn = () => {};
-	mimicFn(wrapper, arrowFn);
+	const prototype = {};
+	wrapper.prototype = prototype;
+	mimicFn(wrapper, foo);
 
-	t.is(wrapper.prototype, arrowFn.prototype);
+	t.is(wrapper.prototype, prototype);
 });

--- a/test.js
+++ b/test.js
@@ -101,3 +101,12 @@ test('should not copy prototypes', t => {
 
 	t.is(wrapper.prototype, prototype);
 });
+
+test('should allow classes', t => {
+	class wrapperClass {}
+	class fooClass {}
+	mimicFn(wrapperClass, fooClass);
+
+	t.is(wrapperClass.name, fooClass.name);
+	t.not(wrapperClass.prototype, fooClass.prototype);
+});


### PR DESCRIPTION
This fixes half of #17.

Functions `prototype` are non-configurable and non-writable, so can never be modified.

This PR skips trying to copy them. This allows using classes (which always have different `prototype`) (or child constructor functions) as arguments to `mimicFn()`.

Note that arrow functions `prototype` property is `undefined`, but it's not very useful to modify it.