### PR TITLE
Wrap `.toString()`

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -14,6 +14,8 @@ Modifies the `to` function to mimic the `from` function. Returns the `to` functi
 
 `name`, `displayName`, and any other properties of `from` are copied. The `length` property is not copied. Prototype, class, and inherited properties are copied.
 
+`to.toString()` will return the same as `from.toString()` but prepended with a `Wrapped with to()` comment.
+
 @param to - Mimicking function.
 @param from - Function to mimic.
 @returns The modified `to` function.

--- a/readme.md
+++ b/readme.md
@@ -37,6 +37,9 @@ console.log(wrapper.name);
 
 console.log(wrapper.unicorn);
 //=> '🦄'
+
+console.log(String(wrapper));
+//=> '/* Wrapped with wrapper() */\nfunction foo() {}'
 ```
 
 
@@ -47,6 +50,8 @@ console.log(wrapper.unicorn);
 Modifies the `to` function to mimic the `from` function. Returns the `to` function.
 
 `name`, `displayName`, and any other properties of `from` are copied. The `length` property is not copied. Prototype, class, and inherited properties are copied.
+
+`to.toString()` will return the same as `from.toString()` but prepended with a `Wrapped with to()` comment.
 
 #### to
 

--- a/test.js
+++ b/test.js
@@ -163,6 +163,15 @@ test('should not modify toString.name', t => {
 	t.is(wrapper.toString.name, 'toString');
 });
 
+test('should work when toString() was patched by original function', t => {
+	const wrapper = function () {};
+	const bar = function () {};
+	bar.toString = () => 'bar.toString()';
+	mimicFn(wrapper, bar);
+
+	t.is(wrapper.toString(), `/* Wrapped with wrapper() */\n${bar.toString()}`);
+});
+
 // eslint-disable-next-line max-params
 const configurableTest = (t, shouldThrow, ignoreNonConfigurable, toDescriptor, fromDescriptor) => {
 	const wrapper = function () {};

--- a/test.js
+++ b/test.js
@@ -53,10 +53,11 @@ test('should keep descriptors', t => {
 	const wrapper = function () {};
 	mimicFn(wrapper, foo);
 
-	const {length: fooLength, ...fooProperties} = Object.getOwnPropertyDescriptors(foo);
-	const {length: wrapperLength, ...wrapperProperties} = Object.getOwnPropertyDescriptors(wrapper);
+	const {length: fooLength, toString: fooToString, ...fooProperties} = Object.getOwnPropertyDescriptors(foo);
+	const {length: wrapperLength, toString: wrapperToString, ...wrapperProperties} = Object.getOwnPropertyDescriptors(wrapper);
 	t.deepEqual(fooProperties, wrapperProperties);
-	t.notDeepEqual(fooLength, wrapperLength);
+	t.not(fooLength, wrapperLength);
+	t.not(fooToString, wrapperToString);
 });
 
 test('should copy inherited properties', t => {
@@ -90,6 +91,76 @@ test('should allow classes to be copied', t => {
 
 	t.is(wrapperClass.name, fooClass.name);
 	t.not(wrapperClass.prototype, fooClass.prototype);
+});
+
+test('should patch toString()', t => {
+	const wrapper = function () {};
+	mimicFn(wrapper, foo);
+
+	t.is(wrapper.toString(), `/* Wrapped with wrapper() */\n${foo.toString()}`);
+});
+
+test('should patch toString() with arrow functions', t => {
+	const wrapper = function () {};
+	const arrowFn = value => value;
+	mimicFn(wrapper, arrowFn);
+
+	t.is(wrapper.toString(), `/* Wrapped with wrapper() */\n${arrowFn.toString()}`);
+});
+
+test('should patch toString() with bound functions', t => {
+	const wrapper = function () {};
+	const boundFn = (() => {}).bind();
+	mimicFn(wrapper, boundFn);
+
+	t.is(wrapper.toString(), `/* Wrapped with wrapper() */\n${boundFn.toString()}`);
+});
+
+test('should patch toString() with new Function()', t => {
+	const wrapper = function () {};
+	// eslint-disable-next-line no-new-func
+	const newFn = new Function('');
+	mimicFn(wrapper, newFn);
+
+	t.is(wrapper.toString(), `/* Wrapped with wrapper() */\n${newFn.toString()}`);
+});
+
+test('should patch toString() several times', t => {
+	const wrapper = function () {};
+	const wrapperTwo = function () {};
+	mimicFn(wrapper, foo);
+	mimicFn(wrapperTwo, wrapper);
+
+	t.is(wrapperTwo.toString(), `/* Wrapped with wrapperTwo() */\n/* Wrapped with wrapper() */\n${foo.toString()}`);
+});
+
+test('should keep toString() non-enumerable', t => {
+	const wrapper = function () {};
+	mimicFn(wrapper, foo);
+
+	const {enumerable} = Object.getOwnPropertyDescriptor(wrapper, 'toString');
+	t.false(enumerable);
+});
+
+test('should print original function with Function.prototype.toString.call()', t => {
+	const wrapper = function () {};
+	mimicFn(wrapper, foo);
+
+	t.is(Function.prototype.toString.call(wrapper), 'function () {}');
+});
+
+test('should work with String()', t => {
+	const wrapper = function () {};
+	mimicFn(wrapper, foo);
+
+	t.is(String(wrapper), `/* Wrapped with wrapper() */\n${foo.toString()}`);
+});
+
+test('should not modify toString.name', t => {
+	const wrapper = function () {};
+	mimicFn(wrapper, foo);
+
+	t.is(wrapper.toString.name, 'toString');
 });
 
 // eslint-disable-next-line max-params


### PR DESCRIPTION
Fixes #1. Previous PR #6.

This wraps `toString()` so that:

```js
const wrappedFn = function() {}
const originalFn = function() { return true }
mimicFn(wrappedFn, originalFn)

console.log(wrappedFn.name)
// originalFn

console.log(wrappedFn.toString())
// /* Wrapped with wrappedFn() */
// function() { return true }
```

The wrapping comment is inserted outside the function body, as opposed to inside. Reasons:
  - I find it easier to read
  - Must easier to implement. Although `function.toString()` has been recently standardized, there are still differences between engines. Different types of functions are also [printed very differently](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Function/toString#Examples) (arrow functions, bound functions, member functions, classes). The body might be on a single line, or not. Those differences makes it harder to insert that comment and be 100% confident every user will get the expected result.
  - Easier to remove for any user trying to parse `function.toString()` (which by itself is a little of a crazy idea).

If a function is wrapped several times, several comments will be stacked on top of each other, as opposed to using a comma-separated list inside a single comment. This was mostly because it was much easier to implement. I also think it makes the wrapping order more obvious: with a comma-separated list, it's not very clear which wrapper was first used.

@jdalton 	@tiagosmartinho