### PR TITLE
Add `ignoreNonConfigurable` option

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -1,3 +1,14 @@
+declare namespace mimicFn {
+	interface Options {
+		/**
+		Skip modifying [non-configurable properties](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object/getOwnPropertyDescriptor#Description) instead of throwing an error.
+
+		@default false
+		*/
+		readonly ignoreNonConfigurable?: boolean;
+	}
+}
+
 /**
 Modifies the `to` function to mimic the `from` function. Returns the `to` function.
 
@@ -36,7 +47,8 @@ declare function mimicFn<
 	FunctionType extends (...arguments: ArgumentsType) => ReturnType
 >(
 	to: (...arguments: ArgumentsType) => ReturnType,
-	from: FunctionType
+	from: FunctionType,
+	options?: mimicFn.Options,
 ): FunctionType;
 
 export = mimicFn;

--- a/index.js
+++ b/index.js
@@ -2,15 +2,33 @@
 
 const {hasOwnProperty} = Object.prototype;
 
-const copyProperty = (to, from, property) => {
+const copyProperty = (to, from, property, {ignoreNonConfigurable = false}) => {
 	// `Function#length` should reflect the parameters of `to` not `from` since we keep its body.
 	// `Function#prototype` is non-writable and non-configurable so can never be modified.
 	if (property === 'length' || property === 'prototype') {
 		return;
 	}
 
-	const descriptor = Object.getOwnPropertyDescriptor(from, property);
-	Object.defineProperty(to, property, descriptor);
+	const toDescriptor = Object.getOwnPropertyDescriptor(to, property);
+	const fromDescriptor = Object.getOwnPropertyDescriptor(from, property);
+
+	if (!canCopyProperty(toDescriptor, fromDescriptor) && ignoreNonConfigurable) {
+		return;
+	}
+
+	Object.defineProperty(to, property, fromDescriptor);
+};
+
+// `Object.defineProperty()` throws if the property exists, is not configurable and either:
+//  - one its descriptors is changed
+//  - it is non-writable and its value is changed
+const canCopyProperty = function (toDescriptor, fromDescriptor) {
+	return toDescriptor === undefined || toDescriptor.configurable || (
+		toDescriptor.writable === fromDescriptor.writable &&
+		toDescriptor.enumerable === fromDescriptor.enumerable &&
+		toDescriptor.configurable === fromDescriptor.configurable &&
+		(toDescriptor.writable || toDescriptor.value === fromDescriptor.value)
+	);
 };
 
 const changePrototype = (to, from) => {
@@ -37,9 +55,9 @@ const removeProperty = (to, from, property) => {
 	}
 };
 
-const mimicFn = (to, from) => {
+const mimicFn = (to, from, opts = {}) => {
 	for (const property of Reflect.ownKeys(from)) {
-		copyProperty(to, from, property);
+		copyProperty(to, from, property, opts);
 	}
 
 	changePrototype(to, from);

--- a/index.js
+++ b/index.js
@@ -55,9 +55,9 @@ const removeProperty = (to, from, property) => {
 	}
 };
 
-const mimicFn = (to, from, opts = {}) => {
+const mimicFn = (to, from, options = {}) => {
 	for (const property of Reflect.ownKeys(from)) {
-		copyProperty(to, from, property, opts);
+		copyProperty(to, from, property, options);
 	}
 
 	changePrototype(to, from);

--- a/readme.md
+++ b/readme.md
@@ -39,7 +39,7 @@ console.log(wrapper.unicorn);
 
 ## API
 
-### mimicFn(to, from)
+### mimicFn(to, from, options?)
 
 Modifies the `to` function to mimic the `from` function. Returns the `to` function.
 
@@ -57,6 +57,16 @@ Type: `Function`
 
 Function to mimic.
 
+#### options
+
+Type: `object`
+
+##### ignoreNonConfigurable
+
+Type: `boolean`<br>
+Default: `false`
+
+Skip modifying [non-configurable properties](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object/getOwnPropertyDescriptor#Description) instead of throwing an error.
 
 ## Related
 

--- a/test.js
+++ b/test.js
@@ -110,3 +110,36 @@ test('should allow classes to be copied', t => {
 	t.is(wrapperClass.name, fooClass.name);
 	t.not(wrapperClass.prototype, fooClass.prototype);
 });
+
+// eslint-disable-next-line max-params
+const configurableTest = (t, shouldThrow, ignoreNonConfigurable, toDescriptor, fromDescriptor) => {
+	const wrapper = function () {};
+	Object.defineProperty(wrapper, 'conf', {value: true, configurable: false, writable: true, enumerable: true, ...toDescriptor});
+
+	const bar = function () {};
+	Object.defineProperty(bar, 'conf', {value: true, configurable: false, writable: true, enumerable: true, ...fromDescriptor});
+
+	if (shouldThrow) {
+		t.throws(() => {
+			mimicFn(wrapper, bar, {ignoreNonConfigurable});
+		});
+	} else {
+		t.notThrows(() => {
+			mimicFn(wrapper, bar, {ignoreNonConfigurable});
+		});
+	}
+};
+
+configurableTest.title = title => `should handle non-configurable properties: ${title}`;
+
+test('not throw with no changes', configurableTest, false, false, {}, {});
+test('not throw with writable value change', configurableTest, false, false, {}, {value: false});
+test('throw with non-writable value change', configurableTest, true, false, {writable: false}, {value: false, writable: false});
+test('not throw with non-writable value change and ignoreNonConfigurable', configurableTest, false, true, {writable: false}, {value: false, writable: false});
+test('throw with configurable change', configurableTest, true, false, {}, {configurable: true});
+test('not throw with configurable change and ignoreNonConfigurable', configurableTest, false, true, {}, {configurable: true});
+test('throw with writable change', configurableTest, true, false, {writable: false}, {writable: true});
+test('not throw with writable change and ignoreNonConfigurable', configurableTest, false, true, {writable: false}, {writable: true});
+test('throw with enumerable change', configurableTest, true, false, {}, {enumerable: false});
+test('not throw with enumerable change and ignoreNonConfigurable', configurableTest, false, true, {}, {enumerable: false});
+test('default ignoreNonConfigurable to false', configurableTest, true, undefined, {}, {enumerable: false});


### PR DESCRIPTION
Fixes #17 and also (to some extent) #10.

This boolean option skips non-configurable options when set to `true`. 

When set to `false` (the default value), an error will be thrown instead when trying to modify non-configurable properties. 

Note that the following is allowed in JavaScript, i.e. does not throw errors: 
  - trying to modify the value of a non-configurable but writable property
  - resetting the descriptors of a non-configurable property, but without modifying their values