### PR TITLE
Use `ignoreNonConfigurable` for properties deletion

### DIFF
--- a/index.js
+++ b/index.js
@@ -2,7 +2,7 @@
 
 const {hasOwnProperty} = Object.prototype;
 
-const copyProperty = (to, from, property, {ignoreNonConfigurable = false}) => {
+const copyProperty = (to, from, property, ignoreNonConfigurable) => {
 	// `Function#length` should reflect the parameters of `to` not `from` since we keep its body.
 	// `Function#prototype` is non-writable and non-configurable so can never be modified.
 	if (property === 'length' || property === 'prototype') {
@@ -41,29 +41,29 @@ const changePrototype = (to, from) => {
 };
 
 // If `to` has properties that `from` does not have, remove them
-const removeProperty = (to, from, property) => {
+const removeProperty = (to, from, property, ignoreNonConfigurable) => {
 	if (hasOwnProperty.call(from, property)) {
 		return;
 	}
 
-	const {configurable, writable} = Object.getOwnPropertyDescriptor(to, property);
+	const {configurable} = Object.getOwnPropertyDescriptor(to, property);
 
-	if (configurable) {
-		delete to[property];
-	} else if (writable) {
-		to[property] = undefined;
+	if (!configurable && ignoreNonConfigurable) {
+		return;
 	}
+
+	delete to[property];
 };
 
-const mimicFn = (to, from, options = {}) => {
+const mimicFn = (to, from, {ignoreNonConfigurable = false} = {}) => {
 	for (const property of Reflect.ownKeys(from)) {
-		copyProperty(to, from, property, options);
+		copyProperty(to, from, property, ignoreNonConfigurable);
 	}
 
 	changePrototype(to, from);
 
 	for (const property of Reflect.ownKeys(to)) {
-		removeProperty(to, from, property);
+		removeProperty(to, from, property, ignoreNonConfigurable);
 	}
 
 	return to;

--- a/test.js
+++ b/test.js
@@ -68,7 +68,7 @@ test('should copy inherited properties', t => {
 	t.is(wrapper.inheritedProp, foo.inheritedProp);
 });
 
-test('should delete extra configurable writable properties', t => {
+test('should delete extra configurable properties', t => {
 	const wrapper = function () {};
 	wrapper.extra = true;
 	mimicFn(wrapper, foo);
@@ -76,21 +76,22 @@ test('should delete extra configurable writable properties', t => {
 	t.false(hasOwnProperty.call(wrapper, 'extra'));
 });
 
-test('should set to undefined extra non-configurable writable properties', t => {
+test('should throw on extra non-configurable properties', t => {
 	const wrapper = function () {};
 	Object.defineProperty(wrapper, 'extra', {value: true, configurable: false, writable: true});
-	mimicFn(wrapper, foo);
 
-	t.true(hasOwnProperty.call(wrapper, 'extra'));
-	t.is(wrapper.extra, undefined);
+	t.throws(() => {
+		mimicFn(wrapper, foo);
+	});
 });
 
-test('should skip extra non-configurable non-writable properties', t => {
+test('should not throw on extra non-configurable properties with ignoreNonConfigurable', t => {
 	const wrapper = function () {};
-	Object.defineProperty(wrapper, 'extra', {value: true, configurable: false, writable: false});
-	mimicFn(wrapper, foo);
+	Object.defineProperty(wrapper, 'extra', {value: true, configurable: false, writable: true});
 
-	t.is(wrapper.extra, true);
+	t.notThrows(() => {
+		mimicFn(wrapper, foo, {ignoreNonConfigurable: true});
+	});
 });
 
 test('should not copy prototypes', t => {


### PR DESCRIPTION
The `ignoreNonConfigurable` option should be used for properties deletion, not only properties copying. Properties are deleted when they exist in `to` but not `from`.

If `ignoreNonConfigurable` is `false` (the default value), non-configurable properties deletion will throw an error. If `true`, it will be ignored instead.

Also currently non-configurable but writable properties are assigned `undefined` instead of throwing an error. This PR removes that behavior for consistency, but let me know if I should add it back.