### PR TITLE
Fix using arrow functions

### DIFF
--- a/index.js
+++ b/index.js
@@ -2,10 +2,12 @@
 
 const {hasOwnProperty} = Object.prototype;
 
+// `Function#length` should reflect the parameters of `to` not `from` since we keep its body.
+// `Function#prototype` is non-writable and non-configurable so can never be modified.
+const shouldSkipProperty = property => property === 'length' || property === 'prototype';
+
 const copyProperty = (to, from, property, ignoreNonConfigurable) => {
-	// `Function#length` should reflect the parameters of `to` not `from` since we keep its body.
-	// `Function#prototype` is non-writable and non-configurable so can never be modified.
-	if (property === 'length' || property === 'prototype') {
+	if (shouldSkipProperty(property)) {
 		return;
 	}
 
@@ -42,7 +44,7 @@ const changePrototype = (to, from) => {
 
 // If `to` has properties that `from` does not have, remove them
 const removeProperty = (to, from, property, ignoreNonConfigurable) => {
-	if (hasOwnProperty.call(from, property)) {
+	if (hasOwnProperty.call(from, property) || shouldSkipProperty(property)) {
 		return;
 	}
 

--- a/test.js
+++ b/test.js
@@ -103,6 +103,14 @@ test('should not copy prototypes', t => {
 	t.is(wrapper.prototype, prototype);
 });
 
+test('should not delete prototypes', t => {
+	const wrapper = function () {};
+	const arrowFn = () => {};
+	mimicFn(wrapper, arrowFn);
+
+	t.not(wrapper.prototype, arrowFn.prototype);
+});
+
 test('should allow classes to be copied', t => {
 	class wrapperClass {}
 	class fooClass {}


### PR DESCRIPTION
Warning: this PR should be discarded if #39 is merged, i.e. #39 should be looked at first.

Using `mimicFn(function to() {}, () => {})` fails because arrow functions do not have any `prototype`. This leads to `delete to.prototype`, which fails because `prototype` is non-configurable.

Previously this would work but #35 removed that behavior.

This PR fixes it by skipping `prototype` deletion.