### PR TITLE
Do not delete additional properties

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -12,7 +12,7 @@ declare namespace mimicFn {
 /**
 Modifies the `to` function to mimic the `from` function. Returns the `to` function.
 
-`name`, `displayName`, and any other properties of `from` are copied. The `length` property is not copied. Properties present in `to` but not in `from` are deleted. Prototype, class, and inherited properties are copied.
+`name`, `displayName`, and any other properties of `from` are copied. The `length` property is not copied. Prototype, class, and inherited properties are copied.
 
 @param to - Mimicking function.
 @param from - Function to mimic.

--- a/index.js
+++ b/index.js
@@ -1,7 +1,5 @@
 'use strict';
 
-const {hasOwnProperty} = Object.prototype;
-
 const copyProperty = (to, from, property, ignoreNonConfigurable) => {
 	// `Function#length` should reflect the parameters of `to` not `from` since we keep its body.
 	// `Function#prototype` is non-writable and non-configurable so can never be modified.
@@ -40,31 +38,12 @@ const changePrototype = (to, from) => {
 	Object.setPrototypeOf(to, fromPrototype);
 };
 
-// If `to` has properties that `from` does not have, remove them
-const removeProperty = (to, from, property, ignoreNonConfigurable) => {
-	if (hasOwnProperty.call(from, property)) {
-		return;
-	}
-
-	const {configurable} = Object.getOwnPropertyDescriptor(to, property);
-
-	if (!configurable && ignoreNonConfigurable) {
-		return;
-	}
-
-	delete to[property];
-};
-
 const mimicFn = (to, from, {ignoreNonConfigurable = false} = {}) => {
 	for (const property of Reflect.ownKeys(from)) {
 		copyProperty(to, from, property, ignoreNonConfigurable);
 	}
 
 	changePrototype(to, from);
-
-	for (const property of Reflect.ownKeys(to)) {
-		removeProperty(to, from, property, ignoreNonConfigurable);
-	}
 
 	return to;
 };

--- a/readme.md
+++ b/readme.md
@@ -43,7 +43,7 @@ console.log(wrapper.unicorn);
 
 Modifies the `to` function to mimic the `from` function. Returns the `to` function.
 
-`name`, `displayName`, and any other properties of `from` are copied. The `length` property is not copied. Properties present in `to` but not in `from` are deleted. Prototype, class, and inherited properties are copied.
+`name`, `displayName`, and any other properties of `from` are copied. The `length` property is not copied. Prototype, class, and inherited properties are copied.
 
 #### to
 

--- a/test.js
+++ b/test.js
@@ -1,8 +1,6 @@
 import test from 'ava';
 import mimicFn from '.';
 
-const {hasOwnProperty} = Object.prototype;
-
 const foo = function (bar) {
 	return bar;
 };
@@ -68,30 +66,12 @@ test('should copy inherited properties', t => {
 	t.is(wrapper.inheritedProp, foo.inheritedProp);
 });
 
-test('should delete extra configurable properties', t => {
+test('should not delete extra configurable properties', t => {
 	const wrapper = function () {};
 	wrapper.extra = true;
 	mimicFn(wrapper, foo);
 
-	t.false(hasOwnProperty.call(wrapper, 'extra'));
-});
-
-test('should throw on extra non-configurable properties', t => {
-	const wrapper = function () {};
-	Object.defineProperty(wrapper, 'extra', {value: true, configurable: false, writable: true});
-
-	t.throws(() => {
-		mimicFn(wrapper, foo);
-	});
-});
-
-test('should not throw on extra non-configurable properties with ignoreNonConfigurable', t => {
-	const wrapper = function () {};
-	Object.defineProperty(wrapper, 'extra', {value: true, configurable: false, writable: true});
-
-	t.notThrows(() => {
-		mimicFn(wrapper, foo, {ignoreNonConfigurable: true});
-	});
+	t.true(wrapper.extra);
 });
 
 test('should not copy prototypes', t => {


### PR DESCRIPTION
This reverses #28.

We delete properties present in `to` but not `from` to make functions more similar.

However I am now thinking this might not be a good idea. Many wrappers add their own static properties, and we should not remove those. For example, a memoizing wrapper might add static properties related to caching, and we don't want to remove this.