### PR TITLE
Improve React Native compatibility

### DIFF
--- a/index.js
+++ b/index.js
@@ -3,7 +3,11 @@
 const copyProperty = (to, from, property, ignoreNonConfigurable) => {
 	// `Function#length` should reflect the parameters of `to` not `from` since we keep its body.
 	// `Function#prototype` is non-writable and non-configurable so can never be modified.
-	if (property === 'length' || property === 'prototype') {
+	// `Function#arguments` and `Function#caller` are present in Reflect.ownKeys for some devices in react-native
+	if (property === 'length' ||
+		property === 'prototype' ||
+		property === 'arguments' ||
+		property === 'caller') {
 		return;
 	}
 

--- a/index.js
+++ b/index.js
@@ -7,7 +7,7 @@ const copyProperty = (to, from, property, ignoreNonConfigurable) => {
 		return;
 	}
 
-	// `Function#arguments` and `Function#caller` are present in Reflect.ownKeys for some devices in react-native
+	// `Function#arguments` and `Function#caller` should not be copied. They were reported to be present in `Reflect.ownKeys` for some devices in React Native (#41), so we explicitly ignore them here.
 	if (property === 'arguments' || property === 'caller') {
 		return;
 	}

--- a/index.js
+++ b/index.js
@@ -3,11 +3,12 @@
 const copyProperty = (to, from, property, ignoreNonConfigurable) => {
 	// `Function#length` should reflect the parameters of `to` not `from` since we keep its body.
 	// `Function#prototype` is non-writable and non-configurable so can never be modified.
+	if (property === 'length' || property === 'prototype') {
+		return;
+	}
+
 	// `Function#arguments` and `Function#caller` are present in Reflect.ownKeys for some devices in react-native
-	if (property === 'length' ||
-		property === 'prototype' ||
-		property === 'arguments' ||
-		property === 'caller') {
+	if (property === 'arguments' || property === 'caller') {
 		return;
 	}
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "mimic-fn",
-	"version": "3.0.0",
+	"version": "3.0.1",
 	"description": "Make a function mimic another one",
 	"license": "MIT",
 	"repository": "sindresorhus/mimic-fn",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "mimic-fn",
-	"version": "3.0.1",
+	"version": "3.0.0",
 	"description": "Make a function mimic another one",
 	"license": "MIT",
 	"repository": "sindresorhus/mimic-fn",


### PR DESCRIPTION
On some devices under React Native a functions Reflect.ownKeys includes 'arguments' and 'caller', which are non-configurable on the target, causing an error.  The 'ignoreNonConfigurable' flag doesn't help, since they are (strangely) _not_ present in the target via getOwnPropertyDescriptor, so 'canCopyProperty' returns true (since toDescriptor is undefined).

Adding them to the initial list (that formerly had only 'length' and 'prototype' solves the problem, albeit at the expense of backward compatibility: in the remote chance that someone deliberately added the property 'arguments' or 'caller' to a function, they would now find that mimicking such a function would not include that property.  That is such a remote edge case, however, versus the certainty that this problem is affecting legitimate, non-edge-case uses of the library (indirectly, in most cases, through mem or p-memoize), that I submit that it is worth the cost.