### PR TITLE
Drop support for Node 12

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -10,11 +10,12 @@ jobs:
       fail-fast: false
       matrix:
         node-version:
+          - 18
+          - 16
           - 14
-          - 12
     steps:
-      - uses: actions/checkout@v2
-      - uses: actions/setup-node@v1
+      - uses: actions/checkout@v3
+      - uses: actions/setup-node@v3
         with:
           node-version: ${{ matrix.node-version }}
       - run: npm install

--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
 	"type": "module",
 	"exports": "./index.js",
 	"engines": {
-		"node": ">=12"
+		"node": ">=14"
 	},
 	"scripts": {
 		"test": "xo && ava && tsd"


### PR DESCRIPTION
This drops support for Node 12 (breaking change) since it is not maintained anymore.
This also adds CI tests for Node 18, and upgrade some GitHub actions.