### PR TITLE
Drop support for Node 14 and 16

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -10,12 +10,12 @@ jobs:
       fail-fast: false
       matrix:
         node-version:
+          - 21
+          - 20
           - 18
-          - 16
-          - 14
     steps:
-      - uses: actions/checkout@v3
-      - uses: actions/setup-node@v3
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
         with:
           node-version: ${{ matrix.node-version }}
       - run: npm install

--- a/index.d.ts
+++ b/index.d.ts
@@ -1,11 +1,11 @@
-export interface Options {
+export type Options = {
 	/**
 	Skip modifying [non-configurable properties](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object/getOwnPropertyDescriptor#Description) instead of throwing an error.
 
 	@default false
 	*/
 	readonly ignoreNonConfigurable?: boolean;
-}
+};
 
 /**
 Modifies the `to` function to mimic the `from` function. Returns the `to` function.
@@ -44,7 +44,7 @@ console.log(wrapper.unicorn);
 export default function mimicFunction<
 	ArgumentsType extends unknown[],
 	ReturnType,
-	FunctionType extends (...arguments: ArgumentsType) => ReturnType
+	FunctionType extends (...arguments: ArgumentsType) => ReturnType,
 >(
 	to: (...arguments: ArgumentsType) => ReturnType,
 	from: FunctionType,

--- a/index.js
+++ b/index.js
@@ -25,10 +25,10 @@ const copyProperty = (to, from, property, ignoreNonConfigurable) => {
 // - it is non-writable and its value is changed
 const canCopyProperty = function (toDescriptor, fromDescriptor) {
 	return toDescriptor === undefined || toDescriptor.configurable || (
-		toDescriptor.writable === fromDescriptor.writable &&
-		toDescriptor.enumerable === fromDescriptor.enumerable &&
-		toDescriptor.configurable === fromDescriptor.configurable &&
-		(toDescriptor.writable || toDescriptor.value === fromDescriptor.value)
+		toDescriptor.writable === fromDescriptor.writable
+		&& toDescriptor.enumerable === fromDescriptor.enumerable
+		&& toDescriptor.configurable === fromDescriptor.configurable
+		&& (toDescriptor.writable || toDescriptor.value === fromDescriptor.value)
 	);
 };
 

--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
 	"type": "module",
 	"exports": "./index.js",
 	"engines": {
-		"node": ">=14"
+		"node": ">=18"
 	},
 	"scripts": {
 		"test": "xo && ava && tsd"
@@ -38,8 +38,8 @@
 		"change"
 	],
 	"devDependencies": {
-		"ava": "^3.15.0",
-		"tsd": "^0.14.0",
-		"xo": "^0.38.2"
+		"ava": "^5.3.1",
+		"tsd": "^0.29.0",
+		"xo": "^0.56.0"
 	}
 }


### PR DESCRIPTION
This drops support for Node 14 and 16, since those are not officially supported anymore.

This also upgrades dependencies. `xo --fix` changed a few lines of code as a result.